### PR TITLE
Add OL7 specific installation directions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,7 +13,13 @@ __ https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/cliconcepts.ht
 Installation
 ============
 
-Mac / Linux
+Oracle Linux 7.x
+----------------
+::
+
+   $ sudo yum install -y python-oci-cli
+
+Mac / Other Linux
 -----------
 ::
 


### PR DESCRIPTION
Update the README to include the preferred OL7 specific install process.
Signed-off-by: craig.carl@oracle.com